### PR TITLE
Don't bail entirely when you can't resolve an asset

### DIFF
--- a/app/assets/javascripts/assets_js.js.erb
+++ b/app/assets/javascripts/assets_js.js.erb
@@ -10,13 +10,13 @@
     # grabbed from Sprockets::Environment#find_asset
     pathname = Pathname.new(logical_path)
     if pathname.absolute?
-      return unless stat(pathname)
+      next unless stat(pathname)
       logical_path = attributes_for(pathname).logical_path
     else
       begin
         pathname = resolve(logical_path)
       rescue Sprockets::FileNotFound
-        return nil
+        next
       end
     end
 


### PR DESCRIPTION
Calling `return` in an `each` loop exits the entire `erb` compilation. The loop should `next` if it can't `stat` or raises a `Sprockets::FileNotFound` exception. Otherwise one bad asset causes the whole script to fail.
